### PR TITLE
Small fix for abbreviations(finalization proof => aggregated finaliza…

### DIFF
--- a/src/app/blocks/[id]/finalization-proof/page.tsx
+++ b/src/app/blocks/[id]/finalization-proof/page.tsx
@@ -11,7 +11,7 @@ type FinalizationProofPageProps = {
 }
 
 export const metadata: Metadata = {
-  title: 'Finalization Proof',
+  title: 'Aggregated Finalization Proof',
 };
 
 export default async function FinalizationProofPage({ params }: FinalizationProofPageProps) {
@@ -24,7 +24,7 @@ export default async function FinalizationProofPage({ params }: FinalizationProo
         <GradientBackground sx={{ pt: 7, pb: 1 }}>
           <Container maxWidth='xl'>
             <Box sx={{ px: { md: 4.5, xs: 0 } }}>
-              <Typography variant='h1'>Block Finalization Proof</Typography>
+              <Typography variant='h1'>AFP for block</Typography>
               <Grid container spacing={1} sx={{ mt: 5 }}>
                 <Grid item xs={12}>
                   <BlurredInfoBlock
@@ -42,7 +42,7 @@ export default async function FinalizationProofPage({ params }: FinalizationProo
 
       <Container maxWidth='xl' sx={{ pb: 7 }}>
         <Box sx={{ px: { md: 4.5, xs: 0 } }}>
-          <BlurredInfoBlock title='Finalization proof:'>
+          <BlurredInfoBlock title='Aggregated finalization proof:'>
             <PrettyJSON data={finalizationProof} />
           </BlurredInfoBlock>
         </Box>

--- a/src/app/blocks/[id]/page.tsx
+++ b/src/app/blocks/[id]/page.tsx
@@ -85,7 +85,7 @@ export default async function BlockByIdPage({ params }: BlockByIdPageProps) {
                             <LaunchIcon
                               color='primary'
                               sx={{ fontSize: '16px', position: 'relative', bottom: '-3px' }}
-                            /> Check finalization proof
+                            /> Check aggregated finalization proof
                           </Typography>
                         </Link>
                       </Box>

--- a/src/data/blocks.ts
+++ b/src/data/blocks.ts
@@ -97,7 +97,7 @@ export async function fetchFinalizationProof(id: string): Promise<FinalizationPr
 
     return await api.get(API_ROUTES.BLOCKS.AGGREGATED_FINALIZATION_PROOF(blockId));
   } catch (e: any) {
-    throw new Error(`Failed to fetch finalization proof by block ID "${blockId}" - ${e.message}`);
+    throw new Error(`Failed to fetch aggregated finalization proof by block ID "${blockId}" - ${e.message}`);
   }
 }
 


### PR DESCRIPTION
Just changed from `finalization proof` to `aggregated finalization proof` because:

1. It's correct naming
2. `Finalization Proof` - a single signature by one quorum member to approve block candidate
3. Block creator collects `Finalization Proofs` from quorum members and once `2/3n+1` of finalization proofs received, it can be aggregated to receive `Aggregated Finalization Proof` - collection of `2/3n+1` finalization proofs by majority of quorum.
4. Block is finalized once `Aggregated Finalization Proof` was created

<br/><br/>

<div align="center">

   **So, it's more correct**

</div>