### PR TITLE
fix(structure): Moved sig type from tx.payload to tx body

### DIFF
--- a/__tests__/helpers/ethereum.unit.ts
+++ b/__tests__/helpers/ethereum.unit.ts
@@ -17,11 +17,11 @@ describe('parseEvmTransaction', () => {
       nonce: 0,
       fee: 230000000000000,
       payload: {
-        sigType: 'ECDSA',
         to: '0x407d73d8a49eeb85d32cf465507dd71d507100c1',
         value: '1.337',
         evmBytecode: 'f09f92a1204b4c594e544152202d3e2034653334643261306232316335346131306134306338643939313837663864636563656266663530316639613135653039323330663138666632616334383038'
       },
+      sigType: 'ECDSA',
       sig: 'ECDSA'
     } as TransactionWithTxHash);
   })

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.1",
   "private": true,
   "scripts": {
-    "dev": "TZ=UTC next dev -H 0.0.0.0",
-    "build": "TZ=UTC next build",
-    "start": "TZ=UTC next start -H 0.0.0.0",
+    "dev": "next dev -H 0.0.0.0",
+    "build": "next build",
+    "start": "next start -H 0.0.0.0",
     "lint": "next lint",
     "test": "TZ=UTC jest --config jest.config.unit.ts",
     "test:integration": "TZ=UTC jest --config jest.config.integration.ts",

--- a/src/app/blocks/[id]/page.tsx
+++ b/src/app/blocks/[id]/page.tsx
@@ -24,7 +24,7 @@ export default async function BlockByIdPage({ params }: PageProps) {
   const txPreviews: TransactionPreview[] = block.transactions.map(tx => ({
     txid: tx.txHash,
     txType: tx.type,
-    sigType: tx.payload.sigType,
+    sigType: tx.sigType,
     fee: tx.fee,
     creator: tx.creator
   }));

--- a/src/definitions/transactions.ts
+++ b/src/definitions/transactions.ts
@@ -7,6 +7,7 @@ export interface Transaction {
   nonce: number;
   fee: number;
   payload: any;
+  sigType: string;
   sig: string;
 }
 

--- a/src/helpers/ethereum.ts
+++ b/src/helpers/ethereum.ts
@@ -14,11 +14,11 @@ export function parseEvmTransaction(tx: EVMTransaction): TransactionWithTxHash {
     nonce: Number(evmTx.nonce),
     fee: Number(evmTx.gasLimit * evmTx.gasPrice),
     payload: {
-      sigType: 'ECDSA',
       to: evmTx.to?.toString(),
       value: Web3.utils.fromWei(evmTx.value.toString(), 'ether'),
       evmBytecode: evmTx.data.toString('hex')
     },
+    sigType: 'ECDSA',
     sig: 'ECDSA'
   };
 }


### PR DESCRIPTION
### Decided to move signature type from payload to transaction body

So now to access the sigType use `tx.sigType` instead of `tx.payload.sigType`